### PR TITLE
Update JSON reader logic

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 DataFrames
 TextParse
 JSON
+Missings


### PR DESCRIPTION
Instead of just using the first Dict returned from the JSON, scan the entire file. For types, use `get` syntax to allow for `missing` to indicate the key doesn't exist. Then, read across the JSON using `row` as before.

Need to test more locally, but it fixed the exact error I had with the flare dataset.